### PR TITLE
Add an editor config file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*]
+end_of_line = lf
+
+indent_size = 2
+indent_style = space
+
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
This aims to ensure a consistent whitespace format in the files. Apparently GitHub respects these files automatically too, so the online editor should also now output files in the desired format.